### PR TITLE
Un-necessary inclusion of component level make file fragments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 #
 
 include Makefile.inc
-include $(wildcard ./*/*.mk)
 export TOP=$(shell pwd)
 # Library and executable names
 LIB=scmi_test


### PR DESCRIPTION
Un-necessary inclusion of component level make file fragments in top level make file.