### PR TITLE
Fix test_b010 parameter count

### DIFF
--- a/test_pool/base/test_b010.c
+++ b/test_pool/base/test_b010.c
@@ -51,6 +51,7 @@ uint32_t base_invalid_messageid_call(void)
     VAL_INIT_TEST_PARAM(param_count, rsp_msg_hdr, return_value_count, status);
     message_id = BASE_INVALID_COMMAND;
     attributes = 0;
+    param_count = 1;
     cmd_msg_hdr = val_msg_hdr_create(PROTOCOL_BASE, BASE_PROTOCOL_MESSAGE_ATTRIBUTES, COMMAND_MSG);
     val_send_message(cmd_msg_hdr, param_count, &message_id, &rsp_msg_hdr, &status,
                      &return_value_count, &attributes);


### PR DESCRIPTION
As stated by the scmi testlist documentation, test_b010 is testing for
an invalid command by first issuing it, and then by verifying the
return status code from the PROTOCOL_MESSAGE_ATTRIBUTES command.

https://github.com/ARM-software/scmi-tests/blob/master/docs/scmi_testlist.md

The PROTOCOL_MESSAGE_ATTRIBUTES requires the message_id to be forwarded
as an argument, hence the num_parameter in the val_send_message should
be set to 1 to make sure the message is constructed with the appropriate
length.

Signed-off-by: Giacomo Travaglini <giacomo.travaglini@arm.com>